### PR TITLE
Anpassung Ausgabe Schalter-Bezeichnung

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -10,7 +10,10 @@ aufgaben_changelog  = Changelog
 aufgaben_description = Beschreibung
 
 aufgaben_task = Aufgabe
+aufgaben_task_hide_title = Erledigte Aufgaben verbergen
 aufgaben_task_hide = Aufgaben verbergen
+aufgaben_task_show_title = Alle Aufgaben anzeigen
+aufgaben_task_show = alle Aufgaben anzeigen
 aufgaben_last_update = Letze Aktualisierung
 
 aufgaben_last_update

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -13,6 +13,13 @@ aufgaben_task = Task
 aufgaben_task_hide = Hide task
 aufgaben_last_update = Last update
 
+aufgaben_task = Task
+aufgaben_task_hide_title = Hide completed tasks
+aufgaben_task_hide = Hide tasks
+aufgaben_task_show_title = Show all Tasks
+aufgaben_task_show = Show all Tasks
+aufgaben_last_update = Last update
+
 aufgaben_last_update
 aufgaben_due = Due
 aufgaben_due_date = Due date

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -13,6 +13,13 @@ aufgaben_task = Tarea
 aufgaben_task_hide = Ocultar tareas
 aufgaben_last_update = Última actualización
 
+aufgaben_task = Tarea
+aufgaben_task_hide_title = Ocultar tareas completadas
+aufgaben_task_hide = Ocultar tareas completadas
+aufgaben_task_show_title = Mostrar todas las tareas
+aufgaben_task_show = Mostrar todas las tareas
+aufgaben_last_update = Última actualización
+
 aufgaben_last_update
 aufgaben_due = Vencido
 aufgaben_due_date = Fecha de vencimiento

--- a/lang/pt_br.lang
+++ b/lang/pt_br.lang
@@ -13,6 +13,13 @@ aufgaben_task = Tarefa
 aufgaben_task_hide = Esconder tarefa
 aufgaben_last_update = Última atualização
 
+aufgaben_task = Tarefa
+aufgaben_task_hide_title = Ocultar tarefas concluídas
+aufgaben_task_hide = Ocultar tarefas concluídas
+aufgaben_task_show_title = Mostrar todas as tarefas
+aufgaben_task_show = Mostrar todas as tarefas
+aufgaben_last_update = Última atualização
+
 aufgaben_last_update
 aufgaben_due = Devido
 aufgaben_due_date = Vencimento

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -10,7 +10,10 @@ aufgaben_changelog  = Changelog
 aufgaben_description = Beskrivning
 
 aufgaben_task = Uppgift
-aufgaben_task_hide = Dölj uppgifterna
+aufgaben_task_hide_title = Dölj slutförda uppgifter
+aufgaben_task_hide = Dölj slutförda uppgifter
+aufgaben_task_show_title = Visa alla uppgifter
+aufgaben_task_show = Visa alla uppgifter
 aufgaben_last_update = Senaste aktualisering
 
 aufgaben_last_update

--- a/pages/aufgaben.php
+++ b/pages/aufgaben.php
@@ -515,11 +515,11 @@ if ($func == '' || $func == 'filter') {
   //
   // --------------------
 
-  if ($aktueller_done_status == 0) {
-    $titleLink = '<a id="doneverbergen" class="erledigtschalter" title="'.$this->i18n('aufgaben_task_hide').'" href="javascript:void(0);">'.$this->i18n('aufgaben_task').'<i class="rex-icon fa-check-square-o"></i></a>';
+    if ($aktueller_done_status == 0) {
+    $titleLink = '<a id="doneverbergen" class="erledigtschalter" title="'.$this->i18n('aufgaben_task_hide').'" href="javascript:void(0);">'.$this->i18n('aufgaben_task_hide_title').'<i class="rex-icon fa-check-square-o"></i></a>';
   }
   else {
-    $titleLink = '<a id="doneanzeigen" class="erledigtschalter" title="Aufgaben anzeigen" href="javascript:void(0);">'.$this->i18n('aufgaben_task').'<i class="rex-icon fa-square-o"></i></a>';
+    $titleLink = '<a id="doneanzeigen" class="erledigtschalter" title="'.$this->i18n('aufgaben_task_show').'" href="javascript:void(0);">'.$this->i18n('aufgaben_task_show_title').'<i class="rex-icon fa-square-o"></i></a>';
   }
 
   $list->setColumnLabel('title', $titleLink);


### PR DESCRIPTION
Erweiterung der lang-Dateien, um die Übersetzung für die Ausgabe "Anzeige aller Aufgaben" bzw. "Ausblenden der erledigten ToDo's" auszugeben. Einsetzen der Variablen in der Datei aufgaben.php

Der Schalter ist dadurch besser sichtbar und auch deutlicher...

edit alexplusde: close #120 